### PR TITLE
Add support for rhel/centos < 7

### DIFF
--- a/tasks/persist-redhat.yml
+++ b/tasks/persist-redhat.yml
@@ -1,6 +1,11 @@
 ---
 - name: Ensure iptables service is installed
   yum: name=iptables-services state=present
+  when: ansible_distribution_major_version >= '7'
+
+- name: Ensure iptables service is installed
+  yum: name=iptables state=present
+  when: ansible_distribution_major_version < '7'
 
 - name: Ensure iptables service is enabled & started
   service: name=iptables enabled=yes state=started


### PR DESCRIPTION
In at least rhel/centos 6 the package providing iptables is called "iptables"