### PR TITLE
Fail during rule loading if iptables reports unknown options

### DIFF
--- a/tasks/rules.yml
+++ b/tasks/rules.yml
@@ -5,6 +5,8 @@
 
 - name: Load v4 rules
   command: /etc/iptables.v4.generated
+  register: v4_script_load_result
+  failed_when: v4_script_load_result.rc != 0 or 'unknown option' in v4_script_load_result.stderr
   when: v4_script|changed
 
 - name: Save v4 rules


### PR DESCRIPTION
The task loading the iptables rules from the remote rule list ignores
stderr output, which can causes misconfigurations to slip into firewall
rules. Instead, the task should preserve the default behavior of failing
on non-zero exit codes, but also fail if the string "unknown option" is
found in the task's stderr.

Closes #5.