### PR TITLE
Added basic support for ip6tables, with a set of basic rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Installation
 Role Variables
 --------------
 
-There are only 3 dictionaries to override in `defaults/main.yml`:
+There are only 6 dictionaries to override in `defaults/main.yml`:
 
 ```
 firewall_v4_default_rules:
@@ -51,6 +51,28 @@ firewall_v4_default_rules:
 firewall_v4_group_rules: {}
 
 firewall_v4_host_rules: {}
+
+firewall_v6_default_rules:
+  001 default policies:
+    - -P INPUT ACCEPT
+    - -P OUTPUT ACCEPT
+    - -P FORWARD DROP
+  002 allow loopback:
+    - -A INPUT -i lo -s ::1/128 -d ::1/128 -j ACCEPT
+    - -A INPUT -i lo -s fe80::/64 -d fe80::/64 -j ACCEPT
+  003 allow ping replies:
+    - -A INPUT -p icmpv6 --icmpv6-type echo-request -j ACCEPT
+    - -A OUTPUT -p icmpv6 --icmpv6-type echo-reply -j ACCEPT
+  100 allow established related:
+    - -A INPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+  200 allow ssh:
+    - -A INPUT -p tcp --dport ssh -j ACCEPT
+  999 drop everything:
+    - -P INPUT DROP
+
+firewall_v6_group_rules: {}
+
+firewall_v6_host_rules: {}
 
 ```
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,3 +19,24 @@ firewall_v4_default_rules:
 firewall_v4_group_rules: {}
 
 firewall_v4_host_rules: {}
+
+firewall_v6_default_rules:
+  001 default policies:
+    - -P INPUT ACCEPT
+    - -P OUTPUT ACCEPT
+    - -P FORWARD DROP
+  002 allow loopback:
+    - -A INPUT -i lo -s ::1/128 -d ::1/128 -j ACCEPT
+  003 allow ping replies:
+    - -A INPUT -p icmpv6 --icmpv6-type echo-request -j ACCEPT
+    - -A OUTPUT -p icmpv6 --icmpv6-type echo-reply -j ACCEPT
+  100 allow established related:
+    - -A INPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+  200 allow ssh:
+    - -A INPUT -p tcp --dport ssh -j ACCEPT
+  999 drop everything:
+    - -P INPUT DROP
+
+firewall_v6_group_rules: {}
+
+firewall_v6_host_rules: {}

--- a/tasks/persist-debian.yml
+++ b/tasks/persist-debian.yml
@@ -8,13 +8,22 @@
 - name: Remove any obsolete v4 saved rules
   file: path=/etc/iptables.v4.saved state=absent
 
+- name: Remove any obsolete v6 save script
+  file: path=/etc/network/if-post-down.d/iptables-v6 state=absent
+
+- name: Remove any obsolete v6 restore script
+  file: path=/etc/network/if-pre-up.d/iptables-v6 state=absent
+
+- name: Remove any obsolete v6 saved rules
+  file: path=/etc/iptables.v6.saved state=absent
+
 - name: Install iptables-persistent
   apt: name=iptables-persistent state=present
 
 - name: Check if netfilter-persistent is present
   shell: which netfilter-persistent
   register: is_netfilter
-  when: v4_script|changed
+  when: v4_script|changed or v6_script|changed
   changed_when: false
   ignore_errors: yes
 
@@ -25,3 +34,13 @@
 - name: Save v4 rules (iptables-persistent)
   command: /etc/init.d/iptables-persistent save
   when: v4_script|changed and is_netfilter.rc == 1
+
+- name: Save v6 rules (netfilter-persistent)
+  command: netfilter-persistent save
+  when: v6_script|changed and is_netfilter.rc == 0
+
+- name: Save v6 rules (iptables-persistent)
+  command: /etc/init.d/iptables-persistent save
+  when: v6_script|changed and is_netfilter.rc == 1
+
+

--- a/tasks/persist-redhat.yml
+++ b/tasks/persist-redhat.yml
@@ -3,6 +3,10 @@
   shell: iptables-save -c > /etc/sysconfig/iptables
   when: v4_script|changed
 
+- name: Save v6 rules (/etc/sysconfig/ip6tables)
+  shell: iptables-save -c > /etc/sysconfig/ip6tables
+  when: v6_script|changed
+
 - name: Ensure iptables service is installed
   yum: name=iptables-services state=present
   when: ansible_distribution_major_version >= '7'

--- a/tasks/rules.yml
+++ b/tasks/rules.yml
@@ -8,3 +8,13 @@
   register: v4_script_load_result
   failed_when: v4_script_load_result.rc != 0 or 'unknown option' in v4_script_load_result.stderr
   when: v4_script|changed
+
+- name: Generate v6 rules
+  template: src=generated.v6.j2 dest=/etc/iptables.v6.generated owner=root group=root mode=755
+  register: v6_script
+
+- name: Load v6 rules
+  command: /etc/iptables.v6.generated
+  register: v6_script_load_result
+  failed_when: v6_script_load_result.rc != 0 or 'unknown option' in v6_script_load_result.stderr
+  when: v6_script|changed

--- a/templates/generated.v6.j2
+++ b/templates/generated.v6.j2
@@ -1,0 +1,24 @@
+#!/bin/sh
+# {{ ansible_managed }}
+{% set merged = firewall_v6_default_rules.copy() %}
+{% set _ = merged.update(firewall_v6_group_rules) %}
+{% set _ = merged.update(firewall_v6_host_rules) %}
+
+# flush rules & delete user-defined chains
+ip6tables -F
+ip6tables -X
+ip6tables -t raw -F
+ip6tables -t raw -X
+ip6tables -t mangle -F
+ip6tables -t mangle -X
+
+{% for group, rules in merged|dictsort  %}
+# {{ group }}
+{% if not rules %}
+# (none)
+{% endif %}
+{% for rule in rules %}
+ip6tables {{ rule }}
+{% endfor %}
+
+{% endfor %}

--- a/tests.yml
+++ b/tests.yml
@@ -11,12 +11,22 @@
           - -A INPUT -p tcp --dport 7890 -j ACCEPT
       firewall_v4_host_rules:
         400 allow 7890: []
+      firewall_v6_group_rules:
+        400 allow http:
+          - -A INPUT -p tcp --dport http -j ACCEPT
+        400 allow 7890:
+          - -A INPUT -p tcp --dport 7890 -j ACCEPT
+      firewall_v6_host_rules:
+        400 allow 7890: []
 
   tasks:
     - name: Retrieve v4 rules
       command: iptables -L -n
       changed_when: false
       register: v4_rules
+    - name: Check that INPUT policy has been applied
+      assert:
+        that: "'Chain INPUT (policy DROP' in v4_rules.stdout"
     - name: Check that a default rule has been applied
       assert:
         that: "'tcp dpt:22' in v4_rules.stdout"
@@ -26,3 +36,20 @@
     - name: Check that deleted rules are deleted
       assert:
         that: "'tcp dpt:7890' not in v4_rules.stdout"
+
+    - name: Retrieve v6 rules
+      command: ip6tables -L -n
+      changed_when: false
+      register: v6_rules
+    - name: Check that INPUT policy has been applied
+      assert:
+        that: "'Chain INPUT (policy DROP' in v6_rules.stdout"
+    - name: Check that a default rule has been applied
+      assert:
+        that: "'tcp dpt:22' in v6_rules.stdout"
+    - name: Check that a group rule has been applied
+      assert:
+        that: "'tcp dpt:80' in v6_rules.stdout"
+    - name: Check that deleted rules are deleted
+      assert:
+        that: "'tcp dpt:7890' not in v6_rules.stdout"


### PR DESCRIPTION
Following issue #8, added a set of basic rules for IPv6 and some templates and documentation. Updated the test script for IPv6 and added a check on INPUT policy.

Tested and passed with Vagrant build.