### PR TITLE
Updated to have valid service handlers for rule changes and disabling of firewalld

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Restart iptables
+  service: name=iptables state=restarted
+
+- name: Restart ip6tables
+  service: name=ip6tables state=restarted

--- a/tasks/persist-redhat.yml
+++ b/tasks/persist-redhat.yml
@@ -21,3 +21,6 @@
 - name: Ensure ip6tables service is enabled & started
   service: name=ip6tables enabled=yes state=started
   when: firewall_v6_configure
+
+- name: Ensure firewalld is disabled and stopped
+  service: name=firewalld enabled=no state=stopped

--- a/tasks/rules.yml
+++ b/tasks/rules.yml
@@ -9,6 +9,7 @@
   register: v4_script_load_result
   failed_when: v4_script_load_result.rc != 0 or 'unknown option' in v4_script_load_result.stderr
   when: v4_script|changed
+  notify: Restart iptables
 
 - name: Generate v6 rules
   template: src=generated.v6.j2 dest=/etc/iptables.v6.generated owner=root group=root mode=755
@@ -20,3 +21,4 @@
   register: v6_script_load_result
   failed_when: v6_script_load_result.rc != 0 or 'unknown option' in v6_script_load_result.stderr
   when: v6_script|changed
+  notify: Restart ip6tables


### PR DESCRIPTION
I've been using this role with CentOSv7. I believe the changes are ubiquitously compatible with RedHat variants of linux, but I'm sure I'll be called out if that's not the case!

Happy to discuss. Certainly something that I seek from this is the inclusion of handlers for restarting iptables, otherwise after a run we have to log onto the node to restart the service for changes to take effect.

Thanks for the awesome role, I look forward to your feedback. 