### PR TITLE
add firewall flush and delete chain command

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,18 @@
 firewall_v4_configure: true
 firewall_v6_configure: false
 
+firewall_v4_flush_chain_command: |
+  iptables --flush
+  iptables -t raw --flush
+  iptables -t nat --flush
+  iptables -t mangle --flush
+
+firewall_v4_delete_chain_command: |
+  iptables --delete-chain
+  iptables -t raw --delete-chain
+  iptables -t nat --delete-chain
+  iptables -t mangle --delete-chain
+
 firewall_v4_default_rules:
   001 default policies:
     - -P INPUT ACCEPT
@@ -20,6 +32,18 @@ firewall_v4_default_rules:
     - -P INPUT DROP
 firewall_v4_group_rules: {}
 firewall_v4_host_rules: {}
+
+firewall_v6_flush_chain_command: |
+  ip6tables --flush
+  ip6tables -t raw --flush
+  ip6tables -t nat --flush
+  ip6tables -t mangle --flush
+
+firewall_v6_delete_chain_command: |
+  ip6tables --delete-chain
+  ip6tables -t raw --delete-chain
+  ip6tables -t nat --delete-chain
+  ip6tables -t mangle --delete-chain
 
 firewall_v6_default_rules:
   001 default policies:

--- a/templates/generated.v4.j2
+++ b/templates/generated.v4.j2
@@ -5,14 +5,8 @@
 {% set _ = merged.update(firewall_v4_host_rules) %}
 
 # flush rules & delete user-defined chains
-iptables -F
-iptables -X
-iptables -t raw -F
-iptables -t raw -X
-iptables -t nat -F
-iptables -t nat -X
-iptables -t mangle -F
-iptables -t mangle -X
+{{ firewall_v4_flush_chain_command }}
+{{ firewall_v4_delete_chain_command }}
 
 {% for group, rules in merged|dictsort  %}
 # {{ group }}

--- a/templates/generated.v6.j2
+++ b/templates/generated.v6.j2
@@ -5,14 +5,8 @@
 {% set _ = merged.update(firewall_v6_host_rules) %}
 
 # flush rules & delete user-defined chains
-ip6tables -F
-ip6tables -X
-ip6tables -t raw -F
-ip6tables -t raw -X
-ip6tables -t nat -F
-ip6tables -t nat -X
-ip6tables -t mangle -F
-ip6tables -t mangle -X
+{{ firewall_v6_flush_chain_command }}
+{{ firewall_v6_delete_chain_command }}
 
 {% for group, rules in merged|dictsort  %}
 # {{ group }}


### PR DESCRIPTION
In order not to rewrite the whole iptables rules I am using, I've implemented instead two command variables for flushing and deleting the chains.  

For example I don't want to touch the FORWARD chain, but I still want to use this firewall role.

 This is what I don't want to care about:

```bash
Chain FORWARD (policy DROP 0 packets, 0 bytes)
 pkts bytes target     prot opt in     out     source               destination         
 3177  350K DOCKER-ISOLATION  all  --  *      *       0.0.0.0/0            0.0.0.0/0           
 3177  350K DOCKER     all  --  *      docker0  0.0.0.0/0            0.0.0.0/0           
 3099  346K ACCEPT     all  --  *      docker0  0.0.0.0/0            0.0.0.0/0            ctstate RELATED,ESTABLISHED
    0     0 ACCEPT     all  --  docker0 !docker0  0.0.0.0/0            0.0.0.0/0           
   78  4680 ACCEPT     all  --  docker0 docker0  0.0.0.0/0            0.0.0.0/0
```

After overriding the command flush and delete, my FORWARD chain remains untouched

```yaml
firewall_v4_flush_chain_command: |
  iptables --flush INPUT
  iptables --flush OUTPUT

firewall_v4_delete_chain_command: ""
```

I was just wondering, if this could be helpful for someone else, so here is the PR