### PR TITLE
Fails if target table does not exist

### DIFF
--- a/tasks/rules.yml
+++ b/tasks/rules.yml
@@ -7,7 +7,10 @@
 - name: Load v4 rules
   command: /etc/iptables.v4.generated
   register: v4_script_load_result
-  failed_when: v4_script_load_result.rc != 0 or 'unknown option' in v4_script_load_result.stderr
+  failed_when: >-
+    v4_script_load_result.rc != 0 or
+    'unknown option' in v4_script_load_result.stderr or
+    'Table does not exist' in v4_script_load_result.stderr
   when: v4_script|changed
 
 - name: Generate v6 rules
@@ -18,5 +21,8 @@
 - name: Load v6 rules
   command: /etc/iptables.v6.generated
   register: v6_script_load_result
-  failed_when: v6_script_load_result.rc != 0 or 'unknown option' in v6_script_load_result.stderr
+  failed_when: >-
+    v6_script_load_result.rc != 0 or
+    'unknown option' in v6_script_load_result.stderr or
+    'Table does not exist' in v6_script_load_result.stderr
   when: v6_script|changed


### PR DESCRIPTION
The iptables wrapper script does not fail on errors via `set -e` or
similar, because failing in the middle of the run could leave the system
is a bad a state. The iptables commands do write to stderr, however,
providing informative error messages that are mostly ignored by the
role.

Similar to how we're already detecting "unknown option" and failing when
found, we'll also fail if iptables reports "Table does not exist",
which is definitely something an administrator will want to know about,
and certainly constitutes a failure mode.

Closes #24.