### PR TITLE
Add comment parameter automatic to firewall rule

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 firewall_v4_configure: true
+firewall_v4_add_comment: false
 firewall_v6_configure: false
 
 firewall_v4_default_rules:

--- a/templates/generated.v4.j2
+++ b/templates/generated.v4.j2
@@ -24,6 +24,7 @@ iptables -t mangle -X
 iptables {{ rule }} -m comment --comment "{{ group }}"
 {% else %}
 iptables {{ rule }}
+{% endif %}
 {% endfor %}
 
 {% endfor %}

--- a/templates/generated.v4.j2
+++ b/templates/generated.v4.j2
@@ -20,6 +20,9 @@ iptables -t mangle -X
 # (none)
 {% endif %}
 {% for rule in rules %}
+{% if not "-m comment --comment" in rule %}
+iptables {{ rule }} -m comment --comment "{{ group }}"
+{% else %}
 iptables {{ rule }}
 {% endfor %}
 

--- a/templates/generated.v4.j2
+++ b/templates/generated.v4.j2
@@ -20,7 +20,7 @@ iptables -t mangle -X
 # (none)
 {% endif %}
 {% for rule in rules %}
-{% if not "-m comment --comment" in rule %}
+{% if not "-m comment --comment" in rule and firewall_v4_add_comment %}
 iptables {{ rule }} -m comment --comment "{{ group }}"
 {% else %}
 iptables {{ rule }}


### PR DESCRIPTION
Maybe it would be nice to have the group name also as comment in iptables.
If you didn't add a 'comment' parameter to the rule before or changed the variable 'firewall_v4_add_comment'  to ' true' .

Kind Regards
Captaln