### PR TITLE
Check if iptables-nft is selected for Debian Buster

### DIFF
--- a/tasks/persist-debian.yml
+++ b/tasks/persist-debian.yml
@@ -9,6 +9,12 @@
 - name: Install iptables-persistent
   apt: name=iptables-persistent state=present
 
+- name: Check if iptables-nft is selected for Debian Buster
+  alternatives:
+    name: iptables
+    path: /usr/sbin/iptables-nft
+  when: ansible_distribution_release == 'buster'
+
 - name: Check if netfilter-persistent is present
   shell: which netfilter-persistent
   register: is_netfilter


### PR DESCRIPTION
According to https://wiki.debian.org/nftables setting iptables-nft with update-alternatives in Debian Buster for using iptables syntax with the nf_tables kernel subsystem.