### PR TITLE
make ip(6)tables scripts fail if rule is wrong

### DIFF
--- a/templates/generated.v4.j2
+++ b/templates/generated.v4.j2
@@ -1,5 +1,6 @@
 #!/bin/sh
 # {{ ansible_managed }}
+set -e
 {% set merged = firewall_v4_default_rules.copy() %}
 {% set _ = merged.update(firewall_v4_group_rules) %}
 {% set _ = merged.update(firewall_v4_host_rules) %}

--- a/templates/generated.v6.j2
+++ b/templates/generated.v6.j2
@@ -1,5 +1,6 @@
 #!/bin/sh
 # {{ ansible_managed }}
+set -e
 {% set merged = firewall_v6_default_rules.copy() %}
 {% set _ = merged.update(firewall_v6_group_rules) %}
 {% set _ = merged.update(firewall_v6_host_rules) %}


### PR DESCRIPTION
Thanks for this awesome role!

Unfortunately the ansible run doesn't fail even if the generated `iptables.v(46).generated` file contain errors.
E. g. for testing I changed the ssh port to something > 65535. Running the script by hand `sudo /etc/iptables.v4.generated" results as expected in iptables complaining about the wrong port number, but the exit code of the shell script is nontheless `0`. Therefore the load v(46) rules` task  is `[OK]` even so no all rules got applied successfully. 

Adding `set -e` to the templates solves this issue since the exit code is non zero if errors occur.

